### PR TITLE
Resolve name collisions

### DIFF
--- a/History.java
+++ b/History.java
@@ -5,22 +5,12 @@ import java.util.Comparator;
 
 import javax.swing.JOptionPane;
 
-/**
- * Write a description of class History here.
- * 
- * @author (your name) 
- * @version (a version number or a date)
- */
 public class History
 {
     private ArrayList<Contest> contests;
     private ArrayList<Member> members;
-
     String lastContestName;
 
-    /**
-     * Constructor for objects of class History
-     */
     public History()
     {
         members = new ArrayList<Member>();
@@ -28,28 +18,32 @@ public class History
         lastContestName = "";
     }
 
-    public void addEntry(String contestName, String memberName, boolean myHasURL, String URL, boolean myHasVotes, int myVotes, boolean myHasUncertainty, int overrideCode)
-    {
+    public void addEntry(String contestName, String memberName, String tag, boolean myHasURL, String URL, boolean myHasVotes, int myVotes, boolean myHasUncertainty, int overrideCode) {
         Contest contestRetrieved;
         // check if the contest being requested hasn't been formed yet
-        if ((contestRetrieved = getContestByName(contestName)) == null)
-        {
+        if ((contestRetrieved = getContestByName(contestName)) == null) {
             // if it hasn't, add it
             contestRetrieved = new Contest(contestName);
             contests.add(contestRetrieved);
         }
 
         Member memberRetrieved;
-        // check if the member being requested hasn't been formed yet
-        if ((memberRetrieved = getMemberByName(memberName)) == null)
-        {
-            // if it hasn't, add it
-            memberRetrieved = new Member(memberName);
-            members.add(memberRetrieved);
+        // Prefer to look up by tag since tags are intended to be unique; otherwise, look up by name
+        if (!tag.isEmpty()) {
+            if ((memberRetrieved = getMemberByTag(tag)) == null) {
+                // If there is no member with this tag, create a new member that has this tag
+                memberRetrieved = new Member(tag, memberName);
+                members.add(memberRetrieved);
+            }
+        } else {
+            if ((memberRetrieved = getMemberByName(memberName)) == null) {
+                // If there is no member with this name, create a new member with this name
+                memberRetrieved = new Member(memberName);
+                members.add(memberRetrieved);
+            }
         }
 
         Entry entryAdding = new Entry(memberRetrieved, contestRetrieved, myHasURL, URL, myHasVotes, myVotes, myHasUncertainty, overrideCode);
-        //System.out.println("Adding entry: " + memberRetrieved.getMostRecentName());
 
         // regardless of the above, add the entry to the member's and contest's records
         contestRetrieved.addEntry(entryAdding);
@@ -183,7 +177,7 @@ public class History
 
                 if (parse.hasMemberInfo && !blockComment)
                 {
-                    addEntry(currentContestName, parse.memberName, parse.hasURL, parse.URL, parse.hasVotes, parse.votes, !parse.hasVotes, parse.overrideCode);
+                    addEntry(currentContestName, parse.memberName, "", parse.hasURL, parse.URL, parse.hasVotes, parse.votes, !parse.hasVotes, parse.overrideCode);
                 }   
 
                 blockComment &= !strLine.endsWith(blockClose);

--- a/History.java
+++ b/History.java
@@ -177,7 +177,7 @@ public class History
 
                 if (parse.hasMemberInfo && !blockComment)
                 {
-                    addEntry(currentContestName, parse.memberName, "", parse.hasURL, parse.URL, parse.hasVotes, parse.votes, !parse.hasVotes, parse.overrideCode);
+                    addEntry(currentContestName, parse.memberName, parse.tag, parse.hasURL, parse.URL, parse.hasVotes, parse.votes, !parse.hasVotes, parse.overrideCode);
                 }   
 
                 blockComment &= !strLine.endsWith(blockClose);

--- a/History.java
+++ b/History.java
@@ -86,7 +86,8 @@ public class History
             DataInputStream in = new DataInputStream(fstream);
             BufferedReader br = new BufferedReader(new InputStreamReader(in));
             String strLine; // String in which to place new lines as they are read
-            String regex = "(\\s+)?>(\\s+)?";   // regular expression to divide associations file
+            String nameRegex = "(\\s+)?>(\\s+)?";   // regular expression to divide associations file
+            String tagRegex = "(\\s+)?\\:(\\s+)?";  // Regular expression that divides lines into a tag section and a names section
             String[] namesRead; // array for the output of the regex split
 
             //Read File Line By Line
@@ -95,10 +96,21 @@ public class History
                 // Ignore empty lines and those starting with two slashes
                 if (!strLine.equals("")  &&  !strLine.startsWith("//"))
                 {
-                    // put the split up names in an array
-                    namesRead = strLine.split(regex);
-                    // incorporate these names into new Member objects (not pretty...)
-                    members.add(new Member(new ArrayList<String>(Arrays.asList(namesRead))));
+                    // If the line contains a colon, we treat all before it as the "tag" for that member.
+                    // If there are multiple colons, everything at and beyond the second colon is ignored.
+                    if (strLine.contains(":")) {
+                        // Divide line into two strings: the tag and the names associated with that tag.
+                        String[] tagSplit = strLine.split(tagRegex);
+                        // Place the split-up names in an array.
+                        namesRead = tagSplit[1].split(nameRegex);
+                        // Incorporate the tag and names into a new Member object.  (Not pretty.)
+                        members.add(new Member(tagSplit[0], new ArrayList<String>(Arrays.asList(namesRead))));                        
+                    } else {
+                        // Place the split-up names in an array.
+                        namesRead = strLine.split(nameRegex);
+                        // Incorporate these names into a new untagged Member object. (Not pretty.)
+                        members.add(new Member(new ArrayList<String>(Arrays.asList(namesRead))));
+                    }
                 }
             }
             //Close the input stream

--- a/History.java
+++ b/History.java
@@ -65,6 +65,15 @@ public class History
         }
         return null;
     }
+    
+    public Member getMemberByTag(String memberTag) {
+        for (int i = 0; i < members.size(); ++i) {
+            if (members.get(i).hasTag() && members.get(i).getTag() == memberTag) {
+                return members.get(i);
+            }
+        }
+        return null;
+    }
 
     public Contest getContestByName(String nameGetting)
     {

--- a/History.java
+++ b/History.java
@@ -62,7 +62,7 @@ public class History
     
     public Member getMemberByTag(String memberTag) {
         for (int i = 0; i < members.size(); ++i) {
-            if (members.get(i).hasTag() && members.get(i).getTag() == memberTag) {
+            if (members.get(i).hasTag() && members.get(i).getTag().equals(memberTag)) {
                 return members.get(i);
             }
         }

--- a/History.java
+++ b/History.java
@@ -108,7 +108,7 @@ public class History
                         // Place the split-up names in an array.
                         namesRead = tagSplit[1].split(nameRegex);
                         // Incorporate the tag and names into a new Member object.  (Not pretty.)
-                        members.add(new Member(tagSplit[0], new ArrayList<String>(Arrays.asList(namesRead))));                        
+                        members.add(new Member(tagSplit[0], new ArrayList<String>(Arrays.asList(namesRead))));
                     } else {
                         // Place the split-up names in an array.
                         namesRead = strLine.split(nameRegex);

--- a/History.java
+++ b/History.java
@@ -31,9 +31,10 @@ public class History
         // Prefer to look up by tag since tags are intended to be unique; otherwise, look up by name
         if (!tag.isEmpty()) {
             if ((memberRetrieved = getMemberByTag(tag)) == null) {
-                // If there is no member with this tag, create a new member that has this tag
+                // If there is no member with this tag, create a new member that has this tag.  (Is this kosher or will we run into duplication issues?)
                 memberRetrieved = new Member(tag, memberName);
                 members.add(memberRetrieved);
+                System.out.println("Warning: tag \"" + tag + "\" in data file does not exist in associations file.");
             }
         } else {
             if ((memberRetrieved = getMemberByName(memberName)) == null) {

--- a/Master.java
+++ b/Master.java
@@ -173,6 +173,9 @@ public abstract class Master
             for (int i=0; i<history.getMembers().size(); i++)
             {
                 out.write(history.getMembers().get(i).getMostRecentName());
+                if (history.getMembers().get(i).hasTag()) {
+                    out.write(" [" + history.getMembers().get(i).getTag() + "]");
+                }
                 out.newLine();
             }
             out.newLine();

--- a/Member.java
+++ b/Member.java
@@ -1,26 +1,20 @@
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * Write a description of class Member here.
- * 
- * @author (your name) 
- * @version (a version number or a date)
- */
 public class Member
 {
-    // instance variables - replace the example below with your own
     private ArrayList<String> names;
     private ArrayList<Entry> entries;
+    private String tag;
+    private boolean isTagged;
 
-    /**
-     * Constructor for objects of class Member
-     */
     public Member()
     {
         // initialise instance variables
         names = new ArrayList<String>();
         entries = new ArrayList<Entry>();
+        tag = new String();
+        isTagged = false;
     }
     
     public Member(String myName)
@@ -28,23 +22,25 @@ public class Member
         names = new ArrayList<String>();
         names.add(myName);
         entries = new ArrayList<Entry>();
+        tag = new String();
+        isTagged = false;
     }
     
-    /**
-     * Constructor for objects of class Member
-     */
     public Member(ArrayList<String> myNames)
     {
         names = myNames;
         entries = new ArrayList<Entry>();
+        tag = new String();
+        isTagged = false;
+    }
+    
+    public Member(String myTag, ArrayList<String> myNames) {
+        names = myNames;
+        entries = new ArrayList<Entry>();
+        tag = myTag;
+        isTagged = true;
     }
 
-    /**
-     * An example of a method - replace this comment with your own
-     * 
-     * @param  y   a sample parameter for a method
-     * @return     the sum of x and y 
-     */
     public void addEntry(Entry entryAdding)
     {
         entries.add(entryAdding);
@@ -73,6 +69,24 @@ public class Member
     public String getMostRecentName()
     {
         return names.get(names.size()-1);
+    }
+    
+    public void setTag(String setting) {
+        tag = setting;
+        isTagged = true;
+    }
+    
+    public void removeTag() {
+        tag = new String();
+        isTagged = false;
+    }
+    
+    public String getTag() {
+        return tag;
+    }
+    
+    public boolean hasTag() {
+        return isTagged;
     }
     
     public int getTotalVotes()

--- a/Member.java
+++ b/Member.java
@@ -25,6 +25,15 @@ public class Member
         isTagged = false;
     }
     
+    public Member(String myTag, String myName)
+    {
+        names = new ArrayList<String>();
+        names.add(myName);
+        entries = new ArrayList<Entry>();
+        tag = myTag;
+        isTagged = true;
+    }
+    
     public Member(ArrayList<String> myNames)
     {
         names = myNames;

--- a/Member.java
+++ b/Member.java
@@ -243,7 +243,7 @@ public class Member
     public ArrayList<Entry> getEntriesWithMostVotes()
     {
         int max = 0;
-        ArrayList maxList = new ArrayList<Entry>();
+        ArrayList<Entry> maxList = new ArrayList<Entry>();
         for (int i=0; i<entries.size(); i++)
         {
             if (entries.get(i).getVotes() == max)
@@ -275,7 +275,7 @@ public class Member
     public ArrayList<Entry> getEntriesWithMostPoints()
     {
         int max = 0;
-        ArrayList maxList = new ArrayList<Entry>();
+        ArrayList<Entry> maxList = new ArrayList<Entry>();
         for (int i=0; i<entries.size(); i++)
         {
             if (entries.get(i).getPoints() == max)

--- a/Member.java
+++ b/Member.java
@@ -10,7 +10,6 @@ public class Member
 
     public Member()
     {
-        // initialise instance variables
         names = new ArrayList<String>();
         entries = new ArrayList<Entry>();
         tag = new String();

--- a/ParsedLine.java
+++ b/ParsedLine.java
@@ -10,6 +10,8 @@ public class ParsedLine
     
     public boolean hasMemberInfo;
     public String memberName;
+    public boolean hasTag;
+    public String tag;
     public boolean hasURL;
     public String URL;
     public boolean hasVotes;
@@ -28,6 +30,10 @@ public class ParsedLine
         
         String regexMember = "(\\s+)?;(\\s+)?";   // regular expression to divide associations file
         String regexContest = "(\\s+)?@(\\s+)?";    // regular expression for the contest number and topic
+        // Regular expression that divides names and tags.  Note that both [ and ] are treated the same way, so tags
+        // don't strictly need to be enclosed by brackets as long as there is at least one present.  For example, the
+        // strings "nicklegends[2237]" and "nicklegends[2237" and "nicklegends  ]2237 [" are all treated the same way.
+        String regexTag = "(\\s+)?\\[|\\](\\s+)?";
         String[] splits;
         
         isBlank = line.equals("");
@@ -37,7 +43,10 @@ public class ParsedLine
         contestName = "";
         hasTopicInfo = false;
         topic = -1;
+        hasMemberInfo = false;
         memberName = "";
+        hasTag = false;
+        tag = "";
         hasURL = false;
         URL = "";
         hasVotes = false;
@@ -79,7 +88,20 @@ public class ParsedLine
             if (splits.length > 0)
             {
                 hasMemberInfo = true;
-                memberName = splits[0];
+                
+                // Split the member into name and tag sections as appropriate nicklegends[2237]
+                String[] tagSplit = splits[0].split(regexTag);
+                if (tagSplit.length > 1) {
+                    hasTag = true;
+                    tag = tagSplit[1];
+                    memberName = tagSplit[0];
+                } else {
+                    hasTag = false;
+                    tag = "";
+                    memberName = tagSplit[0];
+                }
+                
+                System.out.println(hasTag + " " + tag + " " + memberName);
             }
             
             if (splits.length == 2)

--- a/ParsedLine.java
+++ b/ParsedLine.java
@@ -33,7 +33,7 @@ public class ParsedLine
         // Regular expression that divides names and tags.  Note that both [ and ] are treated the same way, so tags
         // don't strictly need to be enclosed by brackets as long as there is at least one present.  For example, the
         // strings "nicklegends[2237]" and "nicklegends[2237" and "nicklegends  ]2237 [" are all treated the same way.
-        String regexTag = "(\\s+)?\\[|\\](\\s+)?";
+        String regexTag = "\\s*(\\[|\\])\\s*";
         String[] splits;
         
         isBlank = line.equals("");
@@ -100,8 +100,6 @@ public class ParsedLine
                     tag = "";
                     memberName = tagSplit[0];
                 }
-                
-                System.out.println(hasTag + " " + tag + " " + memberName);
             }
             
             if (splits.length == 2)

--- a/web/associations.txt
+++ b/web/associations.txt
@@ -28,7 +28,6 @@ XdragonSB > NineLives
 dlbrooks34 > Koh
 Petoe > Peteo
 DragonBoy > /M/
-pikaguy900 > Matthew > Nimono
 Old-Skool > King Aquamentus
 Shiek > Sheik > Sheik91 > Yoshimi > Sheik
 Nuvo > Strato
@@ -99,13 +98,16 @@ joelmacool12 > Joelmacool12 > Joelmacool
 // bmc10011 > TheRock  MAY ONLY APPLY TO MOTM -- look at this further
 sonicfan350 > Zephyr_Eevee > Goriya > Nexas > Eins
 Midnight_King > Shane > Charizard > Shane > Polaris
-UpbeatPenguin > UBP > 744 > Quicksilver > SilverDragon > Noir > Ame > Bengal > Bagel > Ben
 Hero Link > Angeal > Pinkie Pie > Rydia > Angeal > Lana > Linkle
 Koishi > Nekoishi > Plutia
 
-// Problematic due to names shared with other distinct members
-benmw02190 > Ben > Ramblin' Evil Mushroom > Rambly > Truckroid > Rambly
-FlameCursed > Chungus > FlameCursed > Matthew
+// Tagged members: refer to these tags in data.txt when a member's username has been used by a different person
+//   Shared "Ben"
+91: UpbeatPenguin > UBP > 744 > Quicksilver > SilverDragon > Noir > Ame > Bengal > Bagel > Ben
+958: benmw02190 > Ben > Ramblin' Evil Mushroom > Rambly > Truckroid > Rambly
+//   Shared "Matthew"
+3571: pikaguy900 > Matthew > Nimono
+294314: FlameCursed > Chungus > FlameCursed > Matthew
 
 // EDUCATED GUESSES
 DarkSFK > Bob

--- a/web/data.txt
+++ b/web/data.txt
@@ -526,7 +526,7 @@ Shoelace; SOTW65-Shoelace; gif; 1
 Ccc; SOTW65-Ccc; gif; 0
 DragonAtma; SOTW65-DragonAtma; png; 1
 Hero Link; SOTW65-HeroLink; gif; 4
-Ben; SOTW65-Ben; gif; 4
+Ben[958]; SOTW65-Ben; gif; 4
 codelinker; SOTW65-codelinker; GIF; 5
 skateboarder11; SOTW65-skateboarder11; GIF; 0
 
@@ -1084,7 +1084,7 @@ Link75; png; 3
 Linkus Mastii; gif; 31
 
 #147 @ 24469
-Matthew; gif; 1
+Matthew[3571]; gif; 1
 EatinCake; png; 9
 Sir Pimpalot; png; 7
 Blue Link 2007; png; 3
@@ -1186,7 +1186,7 @@ Revfan9; gif; 18
 
 #162 @ 28363
 ennonfenom; jpg; 14
-Matthew; MatthewPZC; gif; 7
+Matthew[3571]; MatthewPZC; gif; 7
 Taco Chopper; jpg; 3
 Trimaster001; jpg; 9
 Turbon714; png; 6


### PR DESCRIPTION
Adds a system by which members can be "tagged" with a string.  This tag can then be referred to in the data file to disambiguate multiple members that submitted shots under the same name at different points in time.