### PR TITLE
Easier losing shot viewing

### DIFF
--- a/ArchivesGenerator.java
+++ b/ArchivesGenerator.java
@@ -82,7 +82,7 @@ public class ArchivesGenerator {
                         out.write("<td class='center has-shot-icon-cell'>");
                         if (entry.hasURL()) {
                             out.write("<a href='" + entry.getURL() + "'>");
-                            out.write("<img class='has-shot-icon' title='Click to view this member&#8217;s shot' src='images/camera.png' onmousemove='hover(event, \"" + entry.getURL() + "\")' onmouseleave='hideHover()'/>");
+                            out.write("<img class='has-shot-icon' title='Click to view this member&#8217;s shot' src='images/camera.png' onmouseenter='enterCamera(\"" + entry.getURL() + "\")' onmousemove='hover(event)' onmouseout='exitCamera()'/>");
                             out.write("</a>");
                         }
                         out.write("</td>");

--- a/ArchivesGenerator.java
+++ b/ArchivesGenerator.java
@@ -82,7 +82,7 @@ public class ArchivesGenerator {
                         out.write("<td class='center has-shot-icon-cell'>");
                         if (entry.hasURL()) {
                             out.write("<a href='" + entry.getURL() + "'>");
-                            out.write("<img class='has-shot-icon' src='images/camera.png'/></a>");
+                            out.write("<img class='has-shot-icon' title='Click to view this member&#8217;s shot' src='images/camera.png'/></a>");
                         }
                         out.write("</td>");
                         

--- a/ArchivesGenerator.java
+++ b/ArchivesGenerator.java
@@ -79,7 +79,7 @@ public class ArchivesGenerator {
                         else
                             out.write("<tr class='entry'>");
 
-                        out.write("<td class='center'>");
+                        out.write("<td class='center has-shot-icon-cell'>");
                         if (entry.hasURL()) {
                             out.write("<a href='" + entry.getURL() + "'>");
                             out.write("<img class='has-shot-icon' src='images/camera.png'/></a>");

--- a/ArchivesGenerator.java
+++ b/ArchivesGenerator.java
@@ -80,8 +80,10 @@ public class ArchivesGenerator {
                             out.write("<tr class='entry'>");
 
                         out.write("<td class='name'>");
-                        if (entry.hasURL())
+                        if (entry.hasURL()) {
                             out.write("<a class='image' href='" + entry.getURL() + "'>");
+                            out.write("<img class='has-shot-icon' src='images/camera.png'/>&nbsp;");
+                        }
                         out.write(entry.getMember().getMostRecentName());
                         if (entry.hasURL())
                             out.write("</a>");

--- a/ArchivesGenerator.java
+++ b/ArchivesGenerator.java
@@ -38,7 +38,7 @@ public class ArchivesGenerator {
                     
                     // If there are no winners in the contest, don't create a cell for the winners' pictures lest we accumulate borders.
                     if (!winners.isEmpty()) {
-                        out.write("<tr><td class='picture-cell' colspan=3>");
+                        out.write("<tr><td class='picture-cell' colspan=4>");
                         for (int j=0; j<winners.size(); j++)
                         {
                             if (!winners.get(j).hasURL()) {
@@ -54,7 +54,7 @@ public class ArchivesGenerator {
                     }
 
                     // Contest title
-                    out.write("<tr><td class='contest-title' colspan=3>");
+                    out.write("<tr><td class='contest-title' colspan=4>");
                     if (contest.hasTopic())
                         out.write("<a class='contest' href='http://www.purezc.net/forums/index.php?showtopic=" + contest.getTopic() + "'>");
                     //out.write("(" + contest.getSynch() + ") "); // TEMPORARY!
@@ -64,7 +64,7 @@ public class ArchivesGenerator {
                     out.write("</td></tr>");
                     
                     out.newLine();
-                    out.write("<tr class='header-row'><td class='left'>Name</td><td class='center'>Votes</td><td class='center'>Points");
+                    out.write("<tr class='header-row'><td></td><td class='left'>Name</td><td class='center'>Votes</td><td class='center'>Points");
                     out.write("<span class='tooltip' title='Votes plus sum of vote margins over lower-ranking shots'>[?]</span>");
                     out.write("</td></tr>");
                     out.newLine();
@@ -79,11 +79,14 @@ public class ArchivesGenerator {
                         else
                             out.write("<tr class='entry'>");
 
-                        out.write("<td class='name'>");
+                        out.write("<td class='center'>");
                         if (entry.hasURL()) {
                             out.write("<a href='" + entry.getURL() + "'>");
-                            out.write("<img class='has-shot-icon' src='images/camera.png'/></a>&nbsp;");
+                            out.write("<img class='has-shot-icon' src='images/camera.png'/></a>");
                         }
+                        out.write("</td>");
+                        
+                        out.write("<td class='name'>");
                         // TODO: Rename 'image' class.  It's a holdover from a much older version of the page.
                         out.write("<a class='image' href='" + UserProfile.getProfileDropboxURL(entry.getMember()) + "'>");
                         out.write(entry.getMember().getMostRecentName());
@@ -113,7 +116,7 @@ public class ArchivesGenerator {
                     //                         out.write("<span class='tie-note'>Screenshot of the Week " + contest.getName() + " ended in a draw.</span>");
                     //                     }
 
-                    out.write("<tr class='info-row'><td class='numentries'>");
+                    out.write("<tr class='info-row'><td></td><td class='numentries'>");
                     out.write(contest.numEntries() + " entr");
                     if (contest.numEntries() != 1)
                         out.write("ies");

--- a/ArchivesGenerator.java
+++ b/ArchivesGenerator.java
@@ -81,13 +81,12 @@ public class ArchivesGenerator {
 
                         out.write("<td class='name'>");
                         if (entry.hasURL()) {
-                            out.write("<a class='image' href='" + entry.getURL() + "'>");
-                            out.write("<img class='has-shot-icon' src='images/camera.png'/>&nbsp;");
+                            out.write("<a href='" + entry.getURL() + "'>");
+                            out.write("<img class='has-shot-icon' src='images/camera.png'/></a>&nbsp;");
                         }
+                        // TODO: Rename 'image' class.  It's a holdover from a much older version of the page.
+                        out.write("<a class='image' href='" + UserProfile.getProfileDropboxURL(entry.getMember()) + "'>");
                         out.write(entry.getMember().getMostRecentName());
-                        if (entry.hasURL())
-                            out.write("</a>");
-                            
                         // Add an icon if the shot won the contest
                         if (isWinner) {
                             out.write(" <img class='winnericon' title='Winner!' src='images/star.png'/>");

--- a/ArchivesGenerator.java
+++ b/ArchivesGenerator.java
@@ -82,7 +82,8 @@ public class ArchivesGenerator {
                         out.write("<td class='center has-shot-icon-cell'>");
                         if (entry.hasURL()) {
                             out.write("<a href='" + entry.getURL() + "'>");
-                            out.write("<img class='has-shot-icon' title='Click to view this member&#8217;s shot' src='images/camera.png'/></a>");
+                            out.write("<img class='has-shot-icon' title='Click to view this member&#8217;s shot' src='images/camera.png' onmousemove='hover(event, \"" + entry.getURL() + "\")' onmouseleave='hideHover()'/>");
+                            out.write("</a>");
                         }
                         out.write("</td>");
                         

--- a/config/archives_header.txt
+++ b/config/archives_header.txt
@@ -37,7 +37,10 @@ function hover(e, image)
 
 function hideHover()
 {
+    hoverimg.style.left = "0px";
+    hoverimg.style.bottom = window.innerHeight + "px";
     hoverimg.style.visibility = "hidden";
+    hoverimg.src = null;
 }
 </script>
 <title>SOTW Archives</title>

--- a/config/archives_header.txt
+++ b/config/archives_header.txt
@@ -24,29 +24,46 @@ function toggle(ID, show)
 	}
 }
 
-function hover(e, image)
+var hover_requested = false;
+
+function hoverLoad()
+{
+    if (hover_requested) {
+      var hoverimg = document.getElementById("hoverimg");
+    	hoverimg.style.visibility = "visible";
+    }
+}
+
+function enterCamera(image)
+{
+    var hoverimg = document.getElementById("hoverimg");
+    hoverimg.src = image;
+    hover_requested = true;
+}
+
+function hover(e)
 {
     var x = e.pageX;
     var y = e.pageY;
     var hoverimg = document.getElementById("hoverimg");
     hoverimg.style.left = (x + 10) + "px";
     hoverimg.style.bottom = (window.innerHeight - (y - 30)) + "px";
-    hoverimg.src = image;
-    hoverimg.style.visibility = "visible";
 }
 
-function hideHover()
+function exitCamera()
 {
+    var hoverimg = document.getElementById("hoverimg");
+    hoverimg.style.visibility = "hidden";
+    hoverimg.src = "images/blank.png";
     hoverimg.style.left = "0px";
     hoverimg.style.bottom = window.innerHeight + "px";
-    hoverimg.style.visibility = "hidden";
-    hoverimg.src = null;
+    hover_requested = false;
 }
 </script>
 <title>SOTW Archives</title>
 </head>
 <body>
-<img id='hoverimg' src=''/>
+<img id='hoverimg' onload='hoverLoad()' src='images/blank.png'/>
 <div class='big-block archives'>
 <div class='grand-title'>Screenshot of the Week Archives</div>
 <div class='updated-text'>Last updated with the results of Screenshot of the Week <span style='font-weight:bold;'>###</span></div>

--- a/config/archives_header.txt
+++ b/config/archives_header.txt
@@ -22,11 +22,28 @@ function toggle(ID, show)
 		closed.style.display = "block";
 		open.style.display = "none";
 	}
-} 
+}
+
+function hover(e, image)
+{
+    var x = e.pageX;
+    var y = e.pageY;
+    var hoverimg = document.getElementById("hoverimg");
+    hoverimg.style.left = (x + 10) + "px";
+    hoverimg.style.bottom = (window.innerHeight - (y - 10)) + "px";
+    hoverimg.src = image;
+    hoverimg.style.visibility = "visible";
+}
+
+function hideHover()
+{
+    hoverimg.style.visibility = "hidden";
+}
 </script>
 <title>SOTW Archives</title>
 </head>
 <body>
+<img id='hoverimg' src=''/>
 <div class='big-block archives'>
 <div class='grand-title'>Screenshot of the Week Archives</div>
 <div class='updated-text'>Last updated with the results of Screenshot of the Week <span style='font-weight:bold;'>###</span></div>

--- a/config/archives_header.txt
+++ b/config/archives_header.txt
@@ -30,7 +30,7 @@ function hover(e, image)
     var y = e.pageY;
     var hoverimg = document.getElementById("hoverimg");
     hoverimg.style.left = (x + 10) + "px";
-    hoverimg.style.bottom = (window.innerHeight - (y - 10)) + "px";
+    hoverimg.style.bottom = (window.innerHeight - (y - 30)) + "px";
     hoverimg.src = image;
     hoverimg.style.visibility = "visible";
 }

--- a/web/style.css
+++ b/web/style.css
@@ -425,4 +425,7 @@ td.contest-cell
 {
   position: absolute;
   visibility: hidden;
+  /*border-style: solid;
+  border-width: 1px;*/
+  box-shadow: 0px 0px 30px 30px #FFFFFF;
 }

--- a/web/style.css
+++ b/web/style.css
@@ -420,3 +420,9 @@ td.contest-cell
 {
   width: 0px;
 }
+
+#hoverimg
+{
+  position: absolute;
+  visibility: hidden;
+}

--- a/web/style.css
+++ b/web/style.css
@@ -413,4 +413,5 @@ td.contest-cell
 .has-shot-icon
 {
   height: 1em;
+  vertical-align: -10%;  /* This is relative to the text, not the cell, because images are inline. */
 }

--- a/web/style.css
+++ b/web/style.css
@@ -415,3 +415,8 @@ td.contest-cell
   height: 1em;
   vertical-align: -10%;  /* This is relative to the text, not the cell, because images are inline. */
 }
+
+.has-shot-icon-cell
+{
+  width: 0px;
+}

--- a/web/style.css
+++ b/web/style.css
@@ -425,7 +425,13 @@ td.contest-cell
 {
   position: absolute;
   visibility: hidden;
-  /*border-style: solid;
-  border-width: 1px;*/
   box-shadow: 0px 0px 30px 30px #FFFFFF;
+
+  /* The below copied from picture-large-div */
+  width: 512px;
+  image-rendering: -moz-crisp-edges;         /* Firefox */
+  image-rendering:   -o-crisp-edges;         /* Opera */
+  image-rendering: -webkit-optimize-contrast;/* Webkit (non-standard naming) */
+  image-rendering: crisp-edges;
+  -ms-interpolation-mode: nearest-neighbor;  /* IE (non-standard property) */
 }

--- a/web/style.css
+++ b/web/style.css
@@ -409,3 +409,8 @@ td.contest-cell
   text-align: center;
   height: 1.75em;
 }
+
+.has-shot-icon
+{
+  height: 1em;
+}


### PR DESCRIPTION
Allows the user to hover over a camera icon next to each entry to see a preview of the image.  Also allows the user to access a member's gallery by clicking on the member's username in the archive.

The hover code is not perfect: sometimes the "blank" image displays while another image loads.  I'm not sure exactly why this happens.  Either way, the issue appears to be rare and minor.