### PR TITLE
Support SOTM in main sequence

### DIFF
--- a/ArchivesGenerator.java
+++ b/ArchivesGenerator.java
@@ -65,8 +65,7 @@ public class ArchivesGenerator {
                 out.write("<tr><td class='contest-title' colspan=5>");
                 if (poll.hasTopic())
                     out.write("<a class='contest' href='http://www.purezc.net/forums/index.php?showtopic=" + poll.getTopic() + "'>");
-                //out.write("(" + poll.getSynch() + ") "); // TEMPORARY!
-                out.write("Screenshot of the Week " + poll.getShortName());
+                out.write(poll.getLongName());
                 if (poll.hasTopic())
                     out.write("</a>");
                 out.write("</td></tr>");

--- a/ArchivesGenerator.java
+++ b/ArchivesGenerator.java
@@ -66,7 +66,7 @@ public class ArchivesGenerator {
                 if (poll.hasTopic())
                     out.write("<a class='contest' href='http://www.purezc.net/forums/index.php?showtopic=" + poll.getTopic() + "'>");
                 //out.write("(" + poll.getSynch() + ") "); // TEMPORARY!
-                out.write("Screenshot of the Week " + poll.getName());
+                out.write("Screenshot of the Week " + poll.getShortName());
                 if (poll.hasTopic())
                     out.write("</a>");
                 out.write("</td></tr>");
@@ -184,7 +184,7 @@ public class ArchivesGenerator {
                 //                     {
                 //                         out.write("<br/>");
                 //                         out.newLine();
-                //                         out.write("<span class='tie-note'>Screenshot of the Week " + poll.getName() + " ended in a draw.</span>");
+                //                         out.write("<span class='tie-note'>Screenshot of the Week " + poll.getShortName() + " ended in a draw.</span>");
                 //                     }
     
                 out.write("<tr class='info-row'><td></td><td class='numentries'>");
@@ -260,7 +260,7 @@ public class ArchivesGenerator {
                     if ((i + 1) == current_page) {
                         out.write(" selected='selected'");
                     }
-                    out.write(">Page " + (i + 1) + " (#" + bounds.getStart().getName() + "&ndash;#" + bounds.getEnd().getName() + ")</option>");
+                    out.write(">Page " + (i + 1) + " (#" + bounds.getStart().getShortName() + "&ndash;#" + bounds.getEnd().getShortName() + ")</option>");
                     out.newLine();
                 }
             }

--- a/ArchivesGenerator.java
+++ b/ArchivesGenerator.java
@@ -180,12 +180,6 @@ public class ArchivesGenerator {
                     out.newLine();
                     out.write("</tr>");
                 }
-                //                     if (winners.size() >= 2)
-                //                     {
-                //                         out.write("<br/>");
-                //                         out.newLine();
-                //                         out.write("<span class='tie-note'>Screenshot of the Week " + poll.getShortName() + " ended in a draw.</span>");
-                //                     }
     
                 out.write("<tr class='info-row'><td></td><td class='numentries'>");
                 out.write(poll.numEntries() + " entr");

--- a/History.java
+++ b/History.java
@@ -49,7 +49,7 @@ public class History {
         // check if the poll being requested hasn't been formed yet
         if ((pollRetrieved = getPollByShortName(pollShortName)) == null) {
             // if it hasn't, add it
-            pollRetrieved = new Poll(pollShortName, hasTopicInfo, topic, currentSynch);
+            pollRetrieved = new Poll(pollShortName, /*temp*/ pollShortName, hasTopicInfo, topic, currentSynch);
             polls.add(pollRetrieved);
         }
 
@@ -281,9 +281,9 @@ public class History {
                             currentSynch++;
 
                         if (parse.hasTopicInfo)
-                            pollRetrieved = new Poll(currentPollShortName, parse.hasTopicInfo, parse.topic, currentSynch);
+                            pollRetrieved = new Poll(currentPollShortName, /*temp*/ currentPollShortName, parse.hasTopicInfo, parse.topic, currentSynch);
                         else
-                            pollRetrieved = new Poll(currentPollShortName, currentSynch);
+                            pollRetrieved = new Poll(currentPollShortName, /*temp*/ currentPollShortName, currentSynch);
                         polls.add(pollRetrieved);
                     }
                 }

--- a/History.java
+++ b/History.java
@@ -28,7 +28,7 @@ public class History {
     }
 
 //     public void addEntry(Entry entry_adding, boolean requestId, int memberId) {
-//         addEntry(entry_adding.getPoll().getName(),
+//         addEntry(entry_adding.getPoll().getShortName(),
 //                  entry_adding.getPoll().hasTopic(),
 //                  entry_adding.getPoll().getTopic(),
 //                  entry_adding.getPoll().getSynch(),
@@ -44,12 +44,12 @@ public class History {
 //                  entry_adding.getOverrideCode());
 //     }
 
-    public void addEntry(String pollName, boolean hasTopicInfo, int topic, int currentSynch, ArrayList<MemberInfo> member_infos, boolean requestId, boolean myHasURL, String URL, boolean myHasVotes, int myVotes, boolean myHasUncertainty, int overrideCode) {
+    public void addEntry(String pollShortName, boolean hasTopicInfo, int topic, int currentSynch, ArrayList<MemberInfo> member_infos, boolean requestId, boolean myHasURL, String URL, boolean myHasVotes, int myVotes, boolean myHasUncertainty, int overrideCode) {
         Poll pollRetrieved;
         // check if the poll being requested hasn't been formed yet
-        if ((pollRetrieved = getPollByName(pollName)) == null) {
+        if ((pollRetrieved = getPollByShortName(pollShortName)) == null) {
             // if it hasn't, add it
-            pollRetrieved = new Poll(pollName, hasTopicInfo, topic, currentSynch);
+            pollRetrieved = new Poll(pollShortName, hasTopicInfo, topic, currentSynch);
             polls.add(pollRetrieved);
         }
 
@@ -138,7 +138,7 @@ public class History {
         }
 
         if (!returning.polls.isEmpty()) {
-            returning.lastPollName = returning.polls.get(returning.polls.size() - 1).getName();
+            returning.lastPollName = returning.polls.get(returning.polls.size() - 1).getShortName();
         }
 
         return returning;
@@ -167,11 +167,12 @@ public class History {
         return members.get(id);
     }
 
-    public Poll getPollByName(String nameGetting)
+    public Poll getPollByShortName(String shortNameGetting)
     {
+        // Why isn't this just a map lookup?
         for (int i=0; i<polls.size(); i++)
         {
-            if (polls.get(i).getName().equals(nameGetting))
+            if (polls.get(i).getShortName().equals(shortNameGetting))
                 return polls.get(i);
         }
         return null;
@@ -238,7 +239,7 @@ public class History {
     }
 
     public boolean populateEntriesFromFile(String filename)
-    {   //IT might be possible in this method to pass references to individual polls instead of "current poll names" and so forth
+    {   //It might be possible in this method to pass references to individual polls instead of "current poll names" and so forth
         try
         {
             // allocate new stream object
@@ -249,7 +250,7 @@ public class History {
             String strLine; // String in which to place new lines as they are read
 
             String[] splits; // array for the output of the regex split
-            String currentPollName = "";
+            String currentPollShortName = "";
             int currentSynch = 0;
             Poll pollRetrieved = null;
 
@@ -268,21 +269,21 @@ public class History {
                     continue;
                 }
                 blockComment |= strLine.startsWith(blockOpen);
-                parse = new ParsedLine(strLine, currentPollName);
+                parse = new ParsedLine(strLine, currentPollShortName);
 
                 if (parse.hasPollInfo && !blockComment)
                 {
-                    currentPollName = parse.pollName; // will change this
+                    currentPollShortName = parse.pollShortName; // will change this
 
-                    if ((pollRetrieved = getPollByName(currentPollName)) == null)
+                    if ((pollRetrieved = getPollByShortName(currentPollShortName)) == null)
                     {
                         if (!parse.synchronous)
                             currentSynch++;
 
                         if (parse.hasTopicInfo)
-                            pollRetrieved = new Poll(currentPollName, parse.hasTopicInfo, parse.topic, currentSynch);
+                            pollRetrieved = new Poll(currentPollShortName, parse.hasTopicInfo, parse.topic, currentSynch);
                         else
-                            pollRetrieved = new Poll(currentPollName, currentSynch);
+                            pollRetrieved = new Poll(currentPollShortName, currentSynch);
                         polls.add(pollRetrieved);
                     }
                 }
@@ -290,7 +291,7 @@ public class History {
                 if (parse.hasMemberInfo && !blockComment)
                 {
                     // addEntry(currentPollName, parse.hasTopicInfo, parse.topic, currentSynch, parse.member_infos, true, -1, parse.hasURL, parse.URL, parse.hasVotes, parse.votes, !parse.hasVotes, parse.overrideCode);
-                    addEntry(currentPollName, parse.hasTopicInfo, parse.topic, currentSynch, parse.member_infos, true, parse.hasURL, parse.URL, parse.hasVotes, parse.votes, !parse.hasVotes, parse.overrideCode);
+                    addEntry(currentPollShortName, parse.hasTopicInfo, parse.topic, currentSynch, parse.member_infos, true, parse.hasURL, parse.URL, parse.hasVotes, parse.votes, !parse.hasVotes, parse.overrideCode);
                  }
 
                 if (parse.isPollNote && !blockComment && pollRetrieved != null) {
@@ -299,7 +300,7 @@ public class History {
 
                 blockComment &= !strLine.endsWith(blockClose);
             }
-            lastPollName = currentPollName;   // this is so we can name the output files intelligently
+            lastPollName = currentPollShortName;   // this is so we can name the output files intelligently
             //Close the input stream
             in.close();
         }

--- a/History.java
+++ b/History.java
@@ -44,12 +44,12 @@ public class History {
 //                  entry_adding.getOverrideCode());
 //     }
 
-    public void addEntry(String pollShortName, boolean hasTopicInfo, int topic, int currentSynch, ArrayList<MemberInfo> member_infos, boolean requestId, boolean myHasURL, String URL, boolean myHasVotes, int myVotes, boolean myHasUncertainty, int overrideCode) {
+    public void addEntry(String pollShortName, String pollLongName, boolean hasTopicInfo, int topic, int currentSynch, ArrayList<MemberInfo> member_infos, boolean requestId, boolean myHasURL, String URL, boolean myHasVotes, int myVotes, boolean myHasUncertainty, int overrideCode) {
         Poll pollRetrieved;
         // check if the poll being requested hasn't been formed yet
         if ((pollRetrieved = getPollByShortName(pollShortName)) == null) {
             // if it hasn't, add it
-            pollRetrieved = new Poll(pollShortName, /*temp*/ pollShortName, hasTopicInfo, topic, currentSynch);
+            pollRetrieved = new Poll(pollShortName, pollLongName, hasTopicInfo, topic, currentSynch);
             polls.add(pollRetrieved);
         }
 
@@ -281,9 +281,9 @@ public class History {
                             currentSynch++;
 
                         if (parse.hasTopicInfo)
-                            pollRetrieved = new Poll(currentPollShortName, /*temp*/ currentPollShortName, parse.hasTopicInfo, parse.topic, currentSynch);
+                            pollRetrieved = new Poll(currentPollShortName, parse.pollLongName, parse.hasTopicInfo, parse.topic, currentSynch);
                         else
-                            pollRetrieved = new Poll(currentPollShortName, /*temp*/ currentPollShortName, currentSynch);
+                            pollRetrieved = new Poll(currentPollShortName, parse.pollLongName, currentSynch);
                         polls.add(pollRetrieved);
                     }
                 }
@@ -291,7 +291,7 @@ public class History {
                 if (parse.hasMemberInfo && !blockComment)
                 {
                     // addEntry(currentPollName, parse.hasTopicInfo, parse.topic, currentSynch, parse.member_infos, true, -1, parse.hasURL, parse.URL, parse.hasVotes, parse.votes, !parse.hasVotes, parse.overrideCode);
-                    addEntry(currentPollShortName, parse.hasTopicInfo, parse.topic, currentSynch, parse.member_infos, true, parse.hasURL, parse.URL, parse.hasVotes, parse.votes, !parse.hasVotes, parse.overrideCode);
+                    addEntry(currentPollShortName, parse.pollLongName, parse.hasTopicInfo, parse.topic, currentSynch, parse.member_infos, true, parse.hasURL, parse.URL, parse.hasVotes, parse.votes, !parse.hasVotes, parse.overrideCode);
                  }
 
                 if (parse.isPollNote && !blockComment && pollRetrieved != null) {

--- a/MemberSortConsecutiveLoose.java
+++ b/MemberSortConsecutiveLoose.java
@@ -43,9 +43,9 @@ public class MemberSortConsecutiveLoose implements MemberDataRetriever
                 Member.EntryStakePair pair = winners.get(h).get(i);
                 
                 if (linkTopics && pair.entry.getPoll().hasTopic()) // NOTE: The below should strip the A and B designations from multi-thread contests
-                    building += ("<a class='green' href='http://www.purezc.net/forums/index.php?showtopic=" + pair.entry.getPoll().getTopic() + "'>#" + pair.entry.getPoll().getName() + "</a>");
+                    building += ("<a class='green' href='http://www.purezc.net/forums/index.php?showtopic=" + pair.entry.getPoll().getTopic() + "'>#" + pair.entry.getPoll().getShortName() + "</a>");
                 else
-                    building += ("#" + pair.entry.getPoll().getName());
+                    building += ("#" + pair.entry.getPoll().getShortName());
                 if (pair.entry.getWinningness() * pair.stake < 1.0f)
                 {
                     building += " (" + getFormat().format(pair.entry.getWinningness() * pair.stake) + ")";

--- a/MemberSortConsecutiveStrict.java
+++ b/MemberSortConsecutiveStrict.java
@@ -43,9 +43,9 @@ public class MemberSortConsecutiveStrict implements MemberDataRetriever
                 Member.EntryStakePair pair = winners.get(h).get(i);
                 
                 if (linkTopics && pair.entry.getPoll().hasTopic()) // NOTE: The below should strip the A and B designations from multi-thread contests
-                    building += ("<a class='green' href='http://www.purezc.net/forums/index.php?showtopic=" + pair.entry.getPoll().getTopic() + "'>#" + pair.entry.getPoll().getName() + "</a>");
+                    building += ("<a class='green' href='http://www.purezc.net/forums/index.php?showtopic=" + pair.entry.getPoll().getTopic() + "'>#" + pair.entry.getPoll().getShortName() + "</a>");
                 else
-                    building += ("#" + pair.entry.getPoll().getName());
+                    building += ("#" + pair.entry.getPoll().getShortName());
                 if (pair.entry.getWinningness() * pair.stake < 1.0f)
                 {
                     building += " (" + getFormat().format(pair.entry.getWinningness() * pair.stake) + ")";

--- a/MemberSortEntries.java
+++ b/MemberSortEntries.java
@@ -35,9 +35,9 @@ public class MemberSortEntries implements MemberDataRetriever
             float stake = pair.stake;
             // The below will strip contests of their letters in the case of multi-thread contests
             if (linkTopics && entry.getPoll().hasTopic()) {
-                building += ("<a class='green' href='http://www.purezc.net/forums/index.php?showtopic=" + entry.getPoll().getTopic() + "'>#" + entry.getPoll().getName() + "</a>");
+                building += ("<a class='green' href='http://www.purezc.net/forums/index.php?showtopic=" + entry.getPoll().getTopic() + "'>#" + entry.getPoll().getShortName() + "</a>");
             } else {
-                building += ("#" + entry.getPoll().getName());
+                building += ("#" + entry.getPoll().getShortName());
             }
             if (stake != 1.0f)
             {

--- a/MemberSortEntryStreak.java
+++ b/MemberSortEntryStreak.java
@@ -42,9 +42,9 @@ public class MemberSortEntryStreak implements MemberDataRetriever
                 Member.EntryStakePair pair = entries.get(h).get(i);
                 
                 if (linkTopics && pair.entry.getPoll().hasTopic()) // NOTE: The below should strip the A and B designations from multi-thread contests
-                    building += ("<a class='green' href='http://www.purezc.net/forums/index.php?showtopic=" + pair.entry.getPoll().getTopic() + "'>#" + pair.entry.getPoll().getName() + "</a>");
+                    building += ("<a class='green' href='http://www.purezc.net/forums/index.php?showtopic=" + pair.entry.getPoll().getTopic() + "'>#" + pair.entry.getPoll().getShortName() + "</a>");
                 else
-                    building += ("#" + pair.entry.getPoll().getName());
+                    building += ("#" + pair.entry.getPoll().getShortName());
                 if (pair.stake < 1.0f)
                 {
                     building += " (" + getFormat().format(pair.stake) + ")";

--- a/MemberSortPlusMinusHeads.java
+++ b/MemberSortPlusMinusHeads.java
@@ -33,9 +33,9 @@ public class MemberSortPlusMinusHeads implements MemberDataRetriever
             else
                 building += ""+getFormat().format(entry.getPlusMinusHeads() * stake);
             if (linkTopics && entry.getPoll().hasTopic())
-                building += (" in <a class='green' href='http://www.purezc.net/forums/index.php?showtopic=" + entry.getPoll().getTopic() + "'>#" + entry.getPoll().getName() + "</a>");
+                building += (" in <a class='green' href='http://www.purezc.net/forums/index.php?showtopic=" + entry.getPoll().getTopic() + "'>#" + entry.getPoll().getShortName() + "</a>");
             else
-                building += (" in #" + entry.getPoll().getName());
+                building += (" in #" + entry.getPoll().getShortName());
             if (i < entries.size()-2)
                 building += ", ";
             else if (i == entries.size()-2)

--- a/MemberSortPlusMinusPoints.java
+++ b/MemberSortPlusMinusPoints.java
@@ -34,9 +34,9 @@ public class MemberSortPlusMinusPoints implements MemberDataRetriever
             else
                 building += ""+getFormat().format(entry.getPlusMinusPoints() * stake);  // Mention stake... later?
             if (linkTopics && entry.getPoll().hasTopic())
-                building += (" in <a class='green' href='http://www.purezc.net/forums/index.php?showtopic=" + entry.getPoll().getTopic() + "'>#" + entry.getPoll().getName() + "</a>");
+                building += (" in <a class='green' href='http://www.purezc.net/forums/index.php?showtopic=" + entry.getPoll().getTopic() + "'>#" + entry.getPoll().getShortName() + "</a>");
             else
-                building += (" in #" + entry.getPoll().getName());
+                building += (" in #" + entry.getPoll().getShortName());
             if (i < entries.size()-2)
                 building += ", ";
             else if (i == entries.size()-2)

--- a/MemberSortPoints.java
+++ b/MemberSortPoints.java
@@ -39,9 +39,9 @@ public class MemberSortPoints implements MemberDataRetriever
             else
                 building += ""+getFormat().format(entry.getPoints() * stake);  // Mention stake... later?
             if (linkTopics && entry.getPoll().hasTopic())
-                building += (" in <a class='green' href='http://www.purezc.net/forums/index.php?showtopic=" + entry.getPoll().getTopic() + "'>#" + entry.getPoll().getName() + "</a>");
+                building += (" in <a class='green' href='http://www.purezc.net/forums/index.php?showtopic=" + entry.getPoll().getTopic() + "'>#" + entry.getPoll().getShortName() + "</a>");
             else
-                building += (" in #" + entry.getPoll().getName());
+                building += (" in #" + entry.getPoll().getShortName());
             if (i < entries.size()-2)
                 building += ", ";
             else if (i == entries.size()-2)

--- a/MemberSortPointsSingle.java
+++ b/MemberSortPointsSingle.java
@@ -44,9 +44,9 @@ public class MemberSortPointsSingle implements MemberDataRetriever
         {
             Member.EntryStakePair pair = winners.get(i);
             if (linkTopics && pair.entry.getPoll().hasTopic()) // NOTE: The below should strip the A and B designations from multi-thread contests
-                building += ("<a class='green' href='http://www.purezc.net/forums/index.php?showtopic=" + pair.entry.getPoll().getTopic() + "'>#" + pair.entry.getPoll().getName() + "</a>");
+                building += ("<a class='green' href='http://www.purezc.net/forums/index.php?showtopic=" + pair.entry.getPoll().getTopic() + "'>#" + pair.entry.getPoll().getShortName() + "</a>");
             else
-                building += ("#" + pair.entry.getPoll().getName());
+                building += ("#" + pair.entry.getPoll().getShortName());
             if (i < winners.size()-2)
                 building += ", ";
             else if (i == winners.size()-2)

--- a/MemberSortVictories.java
+++ b/MemberSortVictories.java
@@ -42,9 +42,9 @@ public class MemberSortVictories implements MemberDataRetriever
             Member.EntryStakePair pair = winners.get(i);
             
             if (linkTopics && pair.entry.getPoll().hasTopic()) // NOTE: The below should strip the A and B designations from multi-thread contests
-                building += ("<a class='green' href='http://www.purezc.net/forums/index.php?showtopic=" + pair.entry.getPoll().getTopic() + "'>#" + pair.entry.getPoll().getName() + "</a>");
+                building += ("<a class='green' href='http://www.purezc.net/forums/index.php?showtopic=" + pair.entry.getPoll().getTopic() + "'>#" + pair.entry.getPoll().getShortName() + "</a>");
             else
-                building += ("#" + pair.entry.getPoll().getName());
+                building += ("#" + pair.entry.getPoll().getShortName());
             if (pair.entry.getWinningness() * pair.stake < 1.0f)
             {
                 building += " (" + getFormat().format(pair.entry.getWinningness() * pair.stake) + ")";

--- a/MemberSortVotes.java
+++ b/MemberSortVotes.java
@@ -39,9 +39,9 @@ public class MemberSortVotes implements MemberDataRetriever
             else
                 building += ""+getFormat().format(entry.getVotes() * stake);  // Could mention stake here... later?
             if (linkTopics && entry.getPoll().hasTopic())
-                building += (" in <a class='green' href='http://www.purezc.net/forums/index.php?showtopic=" + entry.getPoll().getTopic() + "'>#" + entry.getPoll().getName() + "</a>");
+                building += (" in <a class='green' href='http://www.purezc.net/forums/index.php?showtopic=" + entry.getPoll().getTopic() + "'>#" + entry.getPoll().getShortName() + "</a>");
             else
-                building += (" in #" + entry.getPoll().getName());
+                building += (" in #" + entry.getPoll().getShortName());
             if (i < entries.size()-2)
                 building += ", ";
             else if (i == entries.size()-2)

--- a/MemberSortVotesSingle.java
+++ b/MemberSortVotesSingle.java
@@ -44,9 +44,9 @@ public class MemberSortVotesSingle implements MemberDataRetriever
         {
             Member.EntryStakePair pair = winners.get(i);
             if (linkTopics && pair.entry.getPoll().hasTopic()) // NOTE: The below should strip the A and B designations from multi-thread contests
-                building += ("<a class='green' href='http://www.purezc.net/forums/index.php?showtopic=" + pair.entry.getPoll().getTopic() + "'>#" + pair.entry.getPoll().getName() + "</a>");
+                building += ("<a class='green' href='http://www.purezc.net/forums/index.php?showtopic=" + pair.entry.getPoll().getTopic() + "'>#" + pair.entry.getPoll().getShortName() + "</a>");
             else
-                building += ("#" + pair.entry.getPoll().getName());
+                building += ("#" + pair.entry.getPoll().getShortName());
             if (i < winners.size()-2)
                 building += ", ";
             else if (i == winners.size()-2)

--- a/ParsedLine.java
+++ b/ParsedLine.java
@@ -152,7 +152,8 @@ public class ParsedLine
                         pollIDString = "0" + pollIDString;
                      
                     hasURL = true;
-                    URL = "http://sotw.purezc.net/SOTW" + pollIDString + "/" + member_infos.get(0).member_name.replace(" ","%20").replace("'","%27") + "." + splits[1]; // TODO: Do we want to include other members here by default?
+                    String contestTypeString = currentPollShortName.startsWith("M") ? "SOTM" : "SOTW";  // This is ugly and everyone knows it.
+                    URL = "http://sotw.purezc.net/" + contestTypeString + pollIDString + "/" + member_infos.get(0).member_name.replace(" ","%20").replace("'","%27") + "." + splits[1]; // TODO: Do we want to include other members here by default?
                 }
             }
             
@@ -165,7 +166,8 @@ public class ParsedLine
                 while (pollIDString.length() < URL_DIGITS)    // note: this check should use a constant
                     pollIDString = "0" + pollIDString;
                 
-                URL = "http://sotw.purezc.net/SOTW" + pollIDString + "/" + splits[1].replace(" ","%20").replace("'","%27") + "." + splits[2];
+                String contestTypeString = currentPollShortName.startsWith("M") ? "SOTM" : "SOTW";  // This is ugly and everyone knows it.
+                URL = "http://sotw.purezc.net/" + contestTypeString + pollIDString + "/" + splits[1].replace(" ","%20").replace("'","%27") + "." + splits[2];
             }
 
             String voteString = new String();

--- a/ParsedLine.java
+++ b/ParsedLine.java
@@ -26,7 +26,7 @@ public class ParsedLine
     
     private static final double URL_DIGITS = 2;
     
-    public ParsedLine(String line, String currentPollName)
+    public ParsedLine(String line, String currentPollShortName)
     {
         //System.out.println("Starting parse of \"" + line + "\"");
         
@@ -140,7 +140,7 @@ public class ParsedLine
                 else
                 {
                      // treat as extension
-                     String pollIDString = currentPollName.replaceAll("\\D","");  /** REVIEW ME!!!*/
+                     String pollIDString = currentPollShortName.replaceAll("\\D","");  /** REVIEW ME!!!*/
                      while (pollIDString.length() < URL_DIGITS)    // note: this check should use a constant
                         pollIDString = "0" + pollIDString;
                      
@@ -154,7 +154,7 @@ public class ParsedLine
                 voteIndex = 3;
                 hasURL = true;
                 
-                String pollIDString = currentPollName.replaceAll("\\D","");
+                String pollIDString = currentPollShortName.replaceAll("\\D","");
                 while (pollIDString.length() < URL_DIGITS)    // note: this check should use a constant
                     pollIDString = "0" + pollIDString;
                 

--- a/ParsedLine.java
+++ b/ParsedLine.java
@@ -6,7 +6,7 @@ public class ParsedLine
     public boolean isComment;
     
     public boolean hasPollInfo;
-    public String pollName;
+    public String pollShortName;
     public boolean hasTopicInfo;
     public int topic;
     
@@ -44,7 +44,7 @@ public class ParsedLine
         isPollNote = line.startsWith("*");
         
         hasPollInfo = false;
-        pollName = "";
+        pollShortName = "";
         hasTopicInfo = false;
         topic = -1;
         hasMemberInfo = false;
@@ -74,7 +74,7 @@ public class ParsedLine
             if (splits.length >= 1)
             {
                 hasPollInfo = true;
-                pollName = (splits[0].substring(1));  // this will be changed as soon poll names are implemented
+                pollShortName = (splits[0].substring(1));  // this will be changed as soon poll names are implemented
             }
             if (splits.length >= 2)
             {

--- a/Poll.java
+++ b/Poll.java
@@ -161,12 +161,6 @@ public class Poll
         return winners;
     }
     
-    /** TERRIBLE, TERRIBLE, SUPER-KLUDGY METHOD. BEWARE. */
-    public float getApparentPollNumber()
-    {
-        return Float.parseFloat(name.replaceAll("[^0-9.]",""));
-    }
-    
     public int numVotes()
     {
         int sum=0;

--- a/Poll.java
+++ b/Poll.java
@@ -184,6 +184,7 @@ public class Poll
     
     public String getURL()
     {
+        // TODO: Consider architectural benefit of having topics be explicitly assigned.
         if (hasTopic) {
             return "http://www.purezc.net/forums/index.php?showtopic=" + topic;
         } else {

--- a/Poll.java
+++ b/Poll.java
@@ -3,8 +3,7 @@ import java.util.ArrayList;
 public class Poll
 {
     public static final int DEFAULT_SYNCH = -1;
-    // instance variables - replace the example below with your own
-    //private int ID;
+    
     private String shortName;
     private ArrayList<Entry> entries;
     boolean hasTopic;
@@ -12,9 +11,6 @@ public class Poll
     private int synch;
     private ArrayList<String> notes;
     
-    /**
-     * Constructor for objects of class Member
-     */
     public Poll()
     {
         // initialise instance variables
@@ -76,23 +72,10 @@ public class Poll
         return synch;
     }
     
-    /**
-     * An example of a method - replace this comment with your own
-     * 
-     * @param  y   a sample parameter for a method
-     * @return     the sum of x and y 
-     */
     public void addEntry(Entry entryAdding)
     {
         entries.add(entryAdding);
     }
-    
-    /*public void addEntry(Entry entryAdding, boolean incrementSynch)
-    {
-        if (incrementSynch)
-            synch++;            // this is pretty sloppy :(
-        entries.add(entryAdding);
-    }*/
     
     public Entry getEntryByIndex(int index)
     {

--- a/Poll.java
+++ b/Poll.java
@@ -11,59 +11,14 @@ public class Poll
     private int topic;
     private int synch;
     private ArrayList<String> notes;
-    
-    public Poll()
-    {
-        // initialise instance variables
-        shortName = "";
-        longName = "";
-        entries = new ArrayList<Entry>();
-        topic = -1;
-        hasTopic = false;
-        synch = DEFAULT_SYNCH;
-        notes = new ArrayList<String>();
-    }
-    
-    public Poll(String myShortName)
-    {
-        shortName = myShortName;
-        longName = "";
-        entries = new ArrayList<Entry>();
-        topic = -1;
-        hasTopic = false;
-        synch = DEFAULT_SYNCH;
-        notes = new ArrayList<String>();
-    }
       
-    public Poll(String myShortName, int mySynch)
+    public Poll(String myShortName, String myLongName, int mySynch)
     {
         shortName = myShortName;
-        longName = "";
+        longName = myLongName;
         entries = new ArrayList<Entry>();
         topic = -1;
         hasTopic = false;
-        synch = mySynch;
-        notes = new ArrayList<String>();
-    }
-    
-    public Poll(String myShortName, boolean myHasTopic, int myTopic)
-    {
-        shortName = myShortName;
-        longName = "";
-        entries = new ArrayList<Entry>();
-        topic = myTopic;
-        hasTopic = myHasTopic;
-        synch = DEFAULT_SYNCH;
-        notes = new ArrayList<String>();
-    }
-    
-    public Poll(String myShortName, boolean myHasTopic, int myTopic, int mySynch)
-    {
-        shortName = myShortName;
-        longName = "";
-        entries = new ArrayList<Entry>();
-        topic = myTopic;
-        hasTopic = myHasTopic;
         synch = mySynch;
         notes = new ArrayList<String>();
     }

--- a/Poll.java
+++ b/Poll.java
@@ -5,6 +5,7 @@ public class Poll
     public static final int DEFAULT_SYNCH = -1;
     
     private String shortName;
+    private String longName;
     private ArrayList<Entry> entries;
     boolean hasTopic;
     private int topic;
@@ -15,6 +16,7 @@ public class Poll
     {
         // initialise instance variables
         shortName = "";
+        longName = "";
         entries = new ArrayList<Entry>();
         topic = -1;
         hasTopic = false;
@@ -25,6 +27,7 @@ public class Poll
     public Poll(String myShortName)
     {
         shortName = myShortName;
+        longName = "";
         entries = new ArrayList<Entry>();
         topic = -1;
         hasTopic = false;
@@ -35,6 +38,7 @@ public class Poll
     public Poll(String myShortName, int mySynch)
     {
         shortName = myShortName;
+        longName = "";
         entries = new ArrayList<Entry>();
         topic = -1;
         hasTopic = false;
@@ -45,6 +49,7 @@ public class Poll
     public Poll(String myShortName, boolean myHasTopic, int myTopic)
     {
         shortName = myShortName;
+        longName = "";
         entries = new ArrayList<Entry>();
         topic = myTopic;
         hasTopic = myHasTopic;
@@ -55,6 +60,18 @@ public class Poll
     public Poll(String myShortName, boolean myHasTopic, int myTopic, int mySynch)
     {
         shortName = myShortName;
+        longName = "";
+        entries = new ArrayList<Entry>();
+        topic = myTopic;
+        hasTopic = myHasTopic;
+        synch = mySynch;
+        notes = new ArrayList<String>();
+    }
+    
+    public Poll(String myShortName, String myLongName, boolean myHasTopic, int myTopic, int mySynch)
+    {
+        shortName = myShortName;
+        longName = myLongName;
         entries = new ArrayList<Entry>();
         topic = myTopic;
         hasTopic = myHasTopic;
@@ -100,6 +117,11 @@ public class Poll
     public String getShortName()
     {
         return shortName;
+    }
+    
+    public String getLongName()
+    {
+        return longName;
     }
     
     public ArrayList<Entry> getWinners()

--- a/Poll.java
+++ b/Poll.java
@@ -5,7 +5,7 @@ public class Poll
     public static final int DEFAULT_SYNCH = -1;
     // instance variables - replace the example below with your own
     //private int ID;
-    private String name;
+    private String shortName;
     private ArrayList<Entry> entries;
     boolean hasTopic;
     private int topic;
@@ -18,7 +18,7 @@ public class Poll
     public Poll()
     {
         // initialise instance variables
-        name = "";
+        shortName = "";
         entries = new ArrayList<Entry>();
         topic = -1;
         hasTopic = false;
@@ -26,9 +26,9 @@ public class Poll
         notes = new ArrayList<String>();
     }
     
-    public Poll(String myName)
+    public Poll(String myShortName)
     {
-        name = myName;
+        shortName = myShortName;
         entries = new ArrayList<Entry>();
         topic = -1;
         hasTopic = false;
@@ -36,9 +36,9 @@ public class Poll
         notes = new ArrayList<String>();
     }
       
-    public Poll(String myName, int mySynch)
+    public Poll(String myShortName, int mySynch)
     {
-        name = myName;
+        shortName = myShortName;
         entries = new ArrayList<Entry>();
         topic = -1;
         hasTopic = false;
@@ -46,9 +46,9 @@ public class Poll
         notes = new ArrayList<String>();
     }
     
-    public Poll(String myName, boolean myHasTopic, int myTopic)
+    public Poll(String myShortName, boolean myHasTopic, int myTopic)
     {
-        name = myName;
+        shortName = myShortName;
         entries = new ArrayList<Entry>();
         topic = myTopic;
         hasTopic = myHasTopic;
@@ -56,9 +56,9 @@ public class Poll
         notes = new ArrayList<String>();
     }
     
-    public Poll(String myName, boolean myHasTopic, int myTopic, int mySynch)
+    public Poll(String myShortName, boolean myHasTopic, int myTopic, int mySynch)
     {
-        name = myName;
+        shortName = myShortName;
         entries = new ArrayList<Entry>();
         topic = myTopic;
         hasTopic = myHasTopic;
@@ -114,9 +114,9 @@ public class Poll
         return topic;
     }
     
-    public String getName()
+    public String getShortName()
     {
-        return name;
+        return shortName;
     }
     
     public ArrayList<Entry> getWinners()

--- a/ProfileIndexGenerator.java
+++ b/ProfileIndexGenerator.java
@@ -44,8 +44,8 @@ public abstract class ProfileIndexGenerator {
                 data.num_entries = member.getTotalEntries();
                 ArrayList<Member.EntryStakePair> pairs = member.getEntries();
                 if (!pairs.isEmpty()) {
-                    data.first_contest = "#" + pairs.get(0).entry.getPoll().getName();
-                    data.most_recent_contest = "#" + pairs.get(pairs.size() - 1).entry.getPoll().getName();
+                    data.first_contest = "#" + pairs.get(0).entry.getPoll().getShortName();
+                    data.most_recent_contest = "#" + pairs.get(pairs.size() - 1).entry.getPoll().getShortName();
                 } else {
                     data.first_contest = "N/A";
                     data.most_recent_contest = "N/A";

--- a/RandomShotScriptGenerator.java
+++ b/RandomShotScriptGenerator.java
@@ -43,7 +43,7 @@ public abstract class RandomShotScriptGenerator
                         out.write(couples.get(i).member.getMostRecentName());
                     }
                     out.write("', 'contest': '");
-                    out.write(poll.getName());
+                    out.write(poll.getShortName());
                     out.write("', 'hasTopic': '");
                     out.write(poll.hasTopic() ? "true" : "false");
                     out.write("', 'topicUrl': '");

--- a/input/associations.txt
+++ b/input/associations.txt
@@ -129,6 +129,7 @@ Nuvo > Strato > Nuvo > Colin
 ANC > Blackpaintbowser
 shuji > Aroten
 BigJoe > Big Wig Big Joe > BigJoe > No one > BigJoe > IronCreator > BigJoe > Deft War > BigJoe > Adamantium > BigJoe
+GreatJK > Aefre
 
 // Tagged members: refer to these tags in data.txt when a member's username has been used by a different person
 //   Shared "Ben"

--- a/input/data.txt
+++ b/input/data.txt
@@ -5141,9 +5141,29 @@ Taco Chopper; Taco%20Chopper; png; 2
 BigJoe; png; 5
 Jared; png; 24
 Zaxarone; png; 5
-/*
+
 #768 @ 77478
-Jenny; png; 
-Orithan; png; 
-Twilight Knight; png; 
+Jenny; png; 17
+Orithan; png; 4
+Twilight Knight; png; 18
+
+#769 @ 77573
+Blackpaintbowser; png; 3
+Hergiswi; png; 3
+Jenny; png; 10
+Joelmacool; png; 6
+Nightmare; png; 1
+Orithan; png; 6
+Twilight Knight; Twilight%20Knight; png; 13
+
+#M190 @ 77652
+Aefre; png; 21
+Einsiety; png; 5
+Majora; png; 4
+Taco Chopper; Taco%20Chopper; png; 8
+/*
+#M191 @ 77699
+Aroten; png; 28
+Ether; png; 12
+Orithan; png; 8
 /*


### PR DESCRIPTION
Adds functionality for recognizing main-sequence Screenshot of the Month contests and handling them in the expected sequence relative to Screenshot of the Week contests. Note that this does not handle older SOTM contests that featured winners from SOTW.